### PR TITLE
Feat: store tokens in memory

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,0 +1,3 @@
+SLACK_USER_TOKEN=xoxp-XXXX
+PORT=3000
+APP_URL=http://localhost:8080

--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,13 @@ require (
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-playground/validator/v10 v10.4.1 // indirect
 	github.com/golang/protobuf v1.5.1 // indirect
+	github.com/google/uuid v1.2.0 // indirect
 	github.com/joho/godotenv v1.3.0
 	github.com/json-iterator/go v1.1.10 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/slack-go/slack v0.8.2
 	github.com/ugorji/go v1.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/golang/protobuf v1.5.1/go.mod h1:DopwsBzvsk0Fs44TXzsVbJyPhcCPeIwnvohx
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
@@ -55,6 +57,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=
+github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/internal/router/get_authorization_token.go
+++ b/internal/router/get_authorization_token.go
@@ -5,12 +5,15 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jordanleven/slack-onboarder/internal/slackclient"
+	"github.com/jordanleven/slack-onboarder/internal/tokenmanager"
 )
 
 func getAuthorizationToken(c *gin.Context) {
 	code := c.Query("code")
 	authorization := slackclient.GetAuthorization(code)
+	token := tokenmanager.SetToken(authorization)
+
 	c.JSON(http.StatusOK, gin.H{
-		"authorization": authorization,
+		"authorization": token,
 	})
 }

--- a/internal/router/get_authorization_token.go
+++ b/internal/router/get_authorization_token.go
@@ -1,6 +1,8 @@
 package router
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/jordanleven/slack-onboarder/internal/slackclient"
 )
@@ -8,7 +10,7 @@ import (
 func getAuthorizationToken(c *gin.Context) {
 	code := c.Query("code")
 	authorization := slackclient.GetAuthorization(code)
-	c.JSON(200, gin.H{
+	c.JSON(http.StatusOK, gin.H{
 		"authorization": authorization,
 	})
 }

--- a/internal/router/get_channels.go
+++ b/internal/router/get_channels.go
@@ -1,6 +1,8 @@
 package router
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/jordanleven/slack-onboarder/internal/slackclient"
 )
@@ -11,9 +13,9 @@ func getChannels(c *gin.Context) {
 	channels, err := client.GetChannels()
 
 	if err != nil {
-		c.JSON(300, "Error retrieving channels")
+		c.JSON(http.StatusInternalServerError, "Error retrieving channels")
 	} else {
-		c.JSON(200, gin.H{
+		c.JSON(http.StatusOK, gin.H{
 			"channels": channels,
 		})
 	}

--- a/internal/router/post_channels.go
+++ b/internal/router/post_channels.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"net/http"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -28,9 +29,9 @@ func joinChannels(c *gin.Context) {
 	err := client.JoinChannels(chIDs)
 
 	if err != nil {
-		c.JSON(300, "Error joining channels")
+		c.JSON(http.StatusInternalServerError, "Error joining channels")
 	} else {
-		c.JSON(200, gin.H{
+		c.JSON(http.StatusOK, gin.H{
 			"channels": chIDs,
 		})
 	}

--- a/internal/tokenmanager/tokenmanager.go
+++ b/internal/tokenmanager/tokenmanager.go
@@ -1,0 +1,54 @@
+package tokenmanager
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/jordanleven/slack-onboarder/internal/slackclient"
+	uuid "github.com/nu7hatch/gouuid"
+)
+
+const TOKEN_TIME_TO_LIVE_IN_MINUTES = 30
+
+type storedToken struct {
+	SlackToken slackclient.Authorization
+	Expiration time.Time
+}
+
+var storedTokenMap map[string]*storedToken
+
+func init() {
+	storedTokenMap = make(map[string]*storedToken)
+}
+
+func getTimestampCurrent() time.Time {
+	return time.Now()
+}
+
+func getTokenExpiration() time.Time {
+	dt := getTimestampCurrent()
+	return dt.Add(time.Minute * TOKEN_TIME_TO_LIVE_IN_MINUTES)
+}
+
+func getClientToken() (*uuid.UUID, error) {
+	return uuid.NewV4()
+}
+
+func SetToken(slackAuthToken slackclient.Authorization) string {
+	cT, err := getClientToken()
+
+	if err != nil {
+		fmt.Print("Error generating client token")
+		return ""
+	}
+
+	cTString := cT.String()
+	ex := getTokenExpiration()
+
+	storedTokenMap[cTString] = &storedToken{
+		SlackToken: slackAuthToken,
+		Expiration: ex,
+	}
+
+	return cTString
+}


### PR DESCRIPTION
This PR adds support for caching Slack auth tokens in-memory and exposing a client token in the form of a randomly generated UUID.